### PR TITLE
会員側　商品一覧/詳細画面レイアウト

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,32 @@
  *= require_tree .
  *= require_self
  */
- 
+
 @import "bootstrap";
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
+
+.pagination{
+  justify-content:center;
+}
+
+.page,
+.next,
+.last,
+.first,
+.prev{
+  margin:0 5px;
+}
+
+footer{
+  height:100px;
+  width:100%;
+}
+
+.item-box p{
+  font-weight:bold;
+}
+
+main{
+  height:800px;
+}

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,6 +1,7 @@
 class Public::ItemsController < ApplicationController
   def index
     @items = Item.all.page(params[:page]).reverse_order
+    @item_all=Item.all
     p @items
     @genres = Genre.all
   end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.≪ first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last ≫').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next >').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.< previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,9 +8,8 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
-
-  <body>
-    <header class="border-bottom">
+      <body>
+    <header class="border-bottom mb-4">
       <nav class="navbar navbar-expand-lg navbar-light bg-light px-4 pt-4 pb-3">
         <div class="container-fluid">
            <span>
@@ -72,19 +71,19 @@
             <% end %>
           </div>
           <% if admin_signed_in? %>
-            <div class="offset-8 col-4 mt-3">
+            <div class="offset-7 col-5 mt-3">
               <%= form_with url: admin_search_path, method: :get, local: true do |f| %>
               <div class="input-group">
-                <%= f.text_field 'search[value]', placeholder: "Search", size: "26x4",class:"form-control" %>
-                <div class="input-group-append border rounded p-1">
+                <%= f.text_field 'search[value]', placeholder: "Search", size: "26x4",class:"form-control border" %>
+                <div class="input-group-append" >
+                <%= f.select 'search[how]', options_for_select({ "部分一致" => "partical", "前方一致" => "forward", "後方一致" => "backward", "完全一致" => "match" }),{},class:"border px-2" %>
+                </div>
+                <div class="input-group-append border rounded-right px-3">
                   <%= f.button :type => "submit", style: 'border-style: none; background: none;',class:"input-group-btn" do %>
                   <i class="fas fa-search"></i>
                   <% end %>
                 </div>
               </div>
-                <span class="search-button col-xs-12 text-right">
-                  <%= f.select 'search[how]', options_for_select({ "部分一致" => "partical", "前方一致" => "forward", "後方一致" => "backward", "完全一致" => "match" }) %>
-                </span>
               <% end %>
             </div>
           <% else %>
@@ -111,6 +110,9 @@
         </div>
       </nav>
     </header>
+    <main>
     <%= yield %>
+    </main>
   </body>
+  <footer class="border border-top mt-4"></footer>
 </html>

--- a/app/views/public/items/_genre.html.erb
+++ b/app/views/public/items/_genre.html.erb
@@ -1,7 +1,7 @@
-      <table class="table">
+      <table class="table table-borderless border border-secondary">
         <tr>
-          <th>
-            ジャンル検索（仮）
+          <th class="text-center border border-bottom border-secondary">
+            ジャンル検索
           </th>
         </tr>
       <% genres.each do |genre| %>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,25 +1,25 @@
 <div class="container">
   <div class="row">
-    <h1>商品一覧</h1>
-    <span>全<%= @items.ids.count %>件</span>
-  </div>
-  <div class="row">
-    <div class="col">
+    <div class="col-3">
       <%= render 'genre', genres: @genres %>
     </div>
-    <div class="col">
+
+    <div class="col-9">
+      <h2 class="mb-3"><span class="font-weight-bold">商品一覧</span> <small class="text-muted">(全<%= @item_all.count %>件)</small></h2>
+      <div class="row justify-content-left">
       <% @items.each do |item| %>
-        <div class="index_items">
-          <div class="item_image">
-            <%= link_to item_path(item.id) do %>
-              <%= attachment_image_tag item, :image, format: "jpeg", fallback: "no_image.jpg", size: "200x150" %>
-            <% end %>
-            <p><%= link_to item.name, item_path(item.id) %></p>
-            <p>￥<%= item.price.to_s(:delimited) %></p>
-          </div>
-        </div>
+      <div class="col-3 item-box">
+        <%= link_to item_path(item.id) do %>
+          <%= attachment_image_tag item, :image, format: "jpeg", fallback: "no_image.jpg", size: "200x150" %>
+        <% end %>
+        <p class="my-2"><%= link_to item.name, item_path(item.id),class:"text-dark" %></p>
+        <p class="mb-5">￥<%= item.price.to_s(:delimited) %></p>
+      </div>
       <% end %>
-      <%= paginate @items %>
+      </div>
+    </div>
+    <div class="offset-3 col-9">
+    <%= paginate @items ,class:"mr-1 paginate" %>
     </div>
   </div>
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,19 +1,21 @@
 <div class="container">
   <div class="row">
-    <div class="col">
+    <div class="col-3">
       <%= render 'genre', genres: @genres %>
     </div>
-    <div class="col">
-      <%= attachment_image_tag @item, :image, format: "jpeg", fallback: "no_image.jpg", size: "200x150" %>
+    <div class="col-4 d-flex justify-content-center">
+      <%= attachment_image_tag @item, :image, format: "jpeg", fallback: "no_image.jpg", size: "250x200" %>
     </div>
-    <div class="col">
+    <div class="col-5">
       <h2><%= @item.name %></h2>
       <p><%= @item.introduction %></p>
-      <%= @item.add_tax_price.to_s(:delimited) %> (税込)
+      <h4 class="mt-5 mb-4" ><span class="font-weight-bold">¥ <%= @item.add_tax_price.to_s(:delimited) %></span> <span class="small">(税込)</span></h4>
       <%= form_with model: @cart_items do |f| %>
+      <div class="input-group">
         <%= f.hidden_field :item_id, value: @item.id %>
-        <%= f.select :amount, options_for_select((1..20).to_a), include_blank: "個数選択" %>
-        <%= f.submit "カートに入れる" %>
+        <%= f.select :amount, options_for_select((1..20).to_a), {include_blank: "個数選択"} ,{class: "form-control rounded"} %>
+        <%= f.submit "カートに入れる",class:"btn btn-success ml-5" %>
+      </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
会員側　商品一覧ページ、商品詳細ページのレイアウト調整しました。

余白としてfooter追加してます。
body中も余白付けるために、cssでheight指定してます。
ひとまず適当に指定しているだけなので、適宜修正ください。