### PR TITLE
カート一覧レイアウト調整

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -38,9 +38,9 @@ class Public::CartItemsController < ApplicationController
   def update
     @cart_item = CartItem.find(params[:id])
     if @cart_item.update(cart_item_params)
-      redirect_to items_path
+      redirect_to request.referer
     else
-      redirect_to items_path
+      redirect_to request.referer
     end
   end
 

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,50 +1,65 @@
 <div class="container">
-  <div>
-    <span>ショッピングカート</span>
-    <span>
-      <%= link_to "カートを空にする", cart_items_destroy_all_path, method: :delete,class:"btn btn-danger btn-sm" %>
+
+  <div class="row">
+    <h5 class=" col-3 text-center bg-light ">ショッピングカート</h5>
+    <span class="ml-auto col-3 text-right">
+      <%= link_to "カートを空にする", cart_items_destroy_all_path, method: :delete,class:"btn btn-danger px-3" %>
     </span>
   </div>
 
-  <div>
-  　<table class="table">
-    <tr>
+  <div class="row">
+  　<table class="table table-bordered border-secondary ">
+    <thead class="table-secondary">
       <th>商品名</th>
       <th>単価(税込)</th>
       <th>数量</th>
-      <th>合計</th>
+      <th>小計</th>
       <th></th>
-    </tr>
+    </thead>
 
     <!--合計金額を入れる変数sumを定義-->
     <% sum = 0 %>
     <% @cart_items.each do |cart_item| %>
-    <tr>
-      <td><%= cart_item.item.name %></td>
-      <td><%= cart_item.item.add_tax_price.to_s(:delimited) %></td>
+    <tbody>
+      <tr>
       <td>
+        <%= attachment_image_tag cart_item.item, :image, format: "jpeg", fallback: "no_image.jpg", size: "100x75",class:"mr-3" %>
+        <%= cart_item.item.name %>
+      </td>
+      <td class="align-middle"><%= cart_item.item.add_tax_price.to_s(:delimited) %></td>
+      <td class="align-middle">
         <%= form_with model: cart_item, local:true do |f| %>
-          <%= f.select :amount, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20] %>
-          <%= f.submit "変更" %>
+        <div class="input-group row">
+        <div class="ml-auto col-5"><%= f.select :amount, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],{},{class:"form-control"} %></div>
+        <div class="mr-auto col-3"><%= f.submit "変更",class:" btn btn-success" %></div>
+        </div>
         <% end %>
       </td>
-      <td><%= (cart_item.amount*cart_item.item.price*1.1).round.to_s(:delimited) %></td>
-      <td><%= link_to "削除する", cart_item_path(cart_item), method: :delete,class:"btn btn-danger btn-sm" %></td>
-    </tr>
+      <td class="align-middle"><%= (cart_item.amount*cart_item.item.price*1.1).round.to_s(:delimited) %></td>
+      <td class="text-center align-middle"><%= link_to "削除する", cart_item_path(cart_item), method: :delete,class:"btn btn-danger" %></td>
+      </tr>
+    </tbody>
     <% sum += cart_item.amount*cart_item.item.price*1.1 %>
     <% end %>
   　</table>
   </div>
 
-  <div>
-    <span><%= link_to "買い物を続ける", items_path %></span>
-    <table class="table">
+  <div class="row mt-3">
+    <div class="offset-1 col-2">
+      <span><%= link_to "買い物を続ける", items_path,class:"btn btn-primary px-3" %></span>
+    </div>
+    <div class="col-3 ml-auto">
+    <table class="table table-bordered">
       <tr>
-        <th>合計金額</th>
+        <th class="table-secondary">合計金額</th>
         <th><%= sum.round.to_s(:delimited) %></th>
       </tr>
     </table>
+    </div>
   </div>
 
-  <div><p>入力情報に進む</p></div>
+  <div class="col mx-auto">
+    <p class="text-center">入力情報に進む</p>
+  </div>
+
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= attachment_image_tag @item, :image, format: "jpeg", fallback: "no_image.jpg", size: "250x200" %>
     </div>
     <div class="col-5">
-      <h2><%= @item.name %></h2>
+      <h2 class="font-weight-bold"><%= @item.name %></h2>
       <p><%= @item.introduction %></p>
       <h4 class="mt-5 mb-4" ><span class="font-weight-bold">¥ <%= @item.add_tax_price.to_s(:delimited) %></span> <span class="small">(税込)</span></h4>
       <%= form_with model: @cart_items do |f| %>


### PR DESCRIPTION
カート一覧のレイアウト調整しました。

・入力情報に進むの箇所は、link_toでボタンにしないといけないので、修正します