### PR TITLE
管理者側 注文履歴一覧/詳細画面作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -76,3 +76,7 @@ main{
 .genre-tbody{
   background-color:#fdf7ee;
 }
+
+td{
+  vertical-align:center;
+}

--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,7 +1,14 @@
 class Admin::HomesController < ApplicationController
 
   def top
-    @orders=Order.page(params[:page]).per(10)
+    case params[:sort]
+    when "1"
+      customer_id = Rails.application.routes.recognize_path(request.referer)[:id]
+      customer = Customer.find(customer_id)
+      @orders=customer.orders.page(params[:page]).per(10)
+    else
+      @orders=Order.page(params[:page]).per(10)
+    end
   end
 
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,12 +2,15 @@ class Admin::OrdersController < ApplicationController
 
   def show
     @order=Order.find(params[:id])
+    @order_details=OrderDetail.find_by(order_id: @order.id)
   end
 
   def update
     order=Order.find(params[:id])
     order.update(order_params)
     redirect_to request.referer
+
+
   end
 
   private

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -5,7 +5,7 @@
 
       <table class="table">
         <thead>
-          <tr>
+          <tr class="table-active">
             <th>会員ID</th>
             <th>氏名</th>
             <th>メールアドレス</th>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -36,7 +36,7 @@
 
       <div class="offset-4 col-8">
       <%= link_to "編集する",edit_admin_customer_path(@customer),class:"btn btn-success mr-5" %>
-      <%= link_to "注文履歴一覧を見る",admin_root_path,class:"btn btn-primary mx-3" %>
+      <%= link_to "注文履歴一覧を見る",admin_root_path(sort: 1),class:"btn btn-primary mx-3" %>
       </div>
 
     </div>

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,11 +1,13 @@
 <div class="container">
   <div class="row">
     <div class="col">
+    <%if @orders.empty? %>
+      <h3 class="mt-3">注文履歴がありません</h3>
+    <% else %>
       <h3 class="my-3">注文履歴一覧</h3>
-
       <table class="table">
         <thead>
-          <tr>
+          <tr class="table-active">
             <th>購入日時</th>
             <th>購入者</th>
             <th>注文個数</th>
@@ -15,26 +17,15 @@
         <% @orders.each do |order| %>
         <tbody>
           <tr>
-            <td><%= link_to order.created_at.to_s(:datetime_jp) ,admin_order_path(order) %></td>
-            <td><%= order.customer.name %></td>
+            <td><%= link_to order.created_at.to_s(:datetime_jp) ,admin_order_path(order),class:"text-dark border-bottom border-dark" %></td>
+            <td><%= order.customer.full_name %></td>
             <td><%= order.order_details.count %></td>
-            <td>
-              <% if order.status == 0 %>
-                <span>入金待ち</span>
-              <% elsif order.status == 1 %>
-                <span>入金確認</span>
-              <% elsif order.status == 2 %>
-                <span>製作中</span>
-              <% elsif order.status == 3 %>
-                <span>発送準備中</span>
-              <% else order.status == 4 %>
-                <span>発送済み</span>
-              <% end %>
-            </td>
+            <td><%= order.status_i18n %></td>
           </tr>
         </tbody>
         <% end %>
       </table>
+      <% end %>
       <%= paginate(@orders) %>
     </div>
   </div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,20 +1,20 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <h3 class="my-3">注文履歴詳細</h3>
+      <h3 class="my-3"><span class="bg-light">注文履歴詳細</span></h3>
 
       <div class="row">
-        <div class="col">購入者</div>
-        <div class="col"><%= @order.customer.name %></div>
+        <div class="col-2 mb-3 font-weight-bold">購入者</div>
+        <div class="col-10"><span class="border-bottom border-dark"><%= @order.customer.full_name %></span></div>
 
-        <div class="col">注文日</div>
-        <div class="col"><%= @order.created_at.strftime("%Y/%m/%d") %></div>
+        <div class="col-2 mb-3 font-weight-bold">注文日</div>
+        <div class="col-10"><%= @order.created_at.strftime("%Y/%m/%d") %></div>
 
-        <div class="col">配送先</div>
-        <div class="col">〒<%= @order.postal_code %> <%= @order.address %><br><%= @order.name %></div>
+        <div class="col-2 mb-3 font-weight-bold">配送先</div>
+        <div class="col-10">〒<%= @order.postal_code %> <%= @order.address %><br><%= @order.name %></div>
 
-        <div class="col">支払い方法</div>
-        <div class="col">
+        <div class="col-2 my-3 font-weight-bold">支払い方法</div>
+        <div class="col-10 mt-3">
           <% if  @order.payment_method = 0 %>
             クレジットカード
           <% else %>
@@ -22,19 +22,22 @@
           <% end %>
         </div>
 
-        <div class="col">注文ステータス</div>
-        <div class="col">
-          <%= form_with model:order,local:true do |f| %>
-          <%= f.select :status,Order.statuses_i18n.invert,{prompt: false},class:"form-control" %>
-          <%= f.submit "更新" %>
+        <div class="col-2 mb-3 font-weight-bold">注文ステータス</div>
+        <div class="col-6 input-group">
+          <%= form_with model: @order,url:admin_order_path(@order) ,local:true do |f| %>
+          <div class="row">
+          <div class="col-8"><%= f.select :status,Order.statuses_i18n.invert,{prompt: false},class:"form-control" %></div>
+          <div class="col-3"><%= f.submit "更新" ,class:" btn btn-success" %></div>
+          </div>
+          <% end %>
         </div>
       </div>
 
-      <div class="row">
-        <div class="col">
+      <div class="row mt-5">
+        <div class="col-8">
         <table class="table">
           <thead>
-            <tr>
+            <tr class="table-active">
               <th>商品名</th>
               <th>単価(税込)</th>
               <th>数量</th>
@@ -47,14 +50,16 @@
           <% @order.order_details.each do |order_detail| %>
           <tbody>
             <tr>
-              <td><%= order_detail.items.name %></td>
-              <td><%= order_detail.items.add_tax_price %></td>
+              <td><%= order_detail.item.name %></td>
+              <td><%= order_detail.item.add_tax_price.to_s(:delimited) %></td>
               <td><%= order_detail.amount %></td>
-              <td><%= order_detail.price %></td>
-              <td>
-                <%= form_with model:order_detail,local:true do |f| %>
-                <%= f.select :making_status,OrderDetail.making_statuses_i18n.invert,{prompt: false} ,class:"form-control" %>
-                <%= f.submit "更新" %>
+              <td><%= order_detail.price.to_s(:delimited) %></td>
+              <td class="align-middle">
+                <%= form_with model: order_detail,url: admin_order_order_detail_path(@order,order_detail), local:true do |f| %>
+                <div class="input-group row">
+                <div class="ml-auto col-8"><%= f.select :making_status,OrderDetail.making_statuses_i18n.invert,{prompt: false} ,class:"form-control" %></div>
+                <div class="mr-auto col-3"><%= f.submit "更新",class:"btn btn-success" %></div>
+                </div>
                 <% end %>
               </td>
             </tr>
@@ -63,25 +68,29 @@
           <% end %>
         </table>
         </div>
-        <div class="col">
+
+        <div class="offset-1 col-3 d-flex align-items-end">
           <table class="table table-borderless">
             <tbody>
               <tr>
                 <td class="font-weight-bold">商品合計</td>
                 <!--合計金額表示されるか確認する-->
-                <td><%= sum %>円</td>
+                <td class="text-right"><%= sum.to_s(:delimited) %>円</td>
               </tr>
               <tr>
                 <td class="font-weight-bold">送料</td>
-                <td><%= @order.shipping_cost %>円</td>
+                <td class="text-right"><%= @order.shipping_cost.to_s(:delimited) %>円</td>
               </tr>
               <tr>
                 <td class="font-weight-bold">請求金額合計</td>
-                <td><%= @order.total_payment %>円</td>
+                <td class="font-weight-bold text-right"><%= @order.total_payment.to_s(:delimited) %>円</td>
               </tr>
             </tbody>
           </table>
         </div>
+
       </div>
+
     </div>
+</div>
 </div>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -58,8 +58,8 @@
     </div>
   </div>
 
-  <div class="col mx-auto">
-    <span><%= link_to "入力情報に進む", new_order_path,class:"btn btn-primary px-3" %></span>
+  <div class="row justify-content-center">
+    <%= link_to "入力情報に進む", new_order_path,class:"btn btn-primary px-3" %>
   </div>
 
 </div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,1 +1,1 @@
-Time::DATE_FORMATS[:datetime_jp] = '%Y/ %m/ %d %H: %M: %S'
+Time::DATE_FORMATS[:datetime_jp] = '%Y/%m/%d %H:%M:%S'


### PR DESCRIPTION
管理者側　注文履歴一覧画面と注文履歴詳細画面作成しました。

管理者トップページですが、
ヘッダーのボタンから遷移した場合は、全ての注文履歴を、
会員詳細画面のボタンから遷移した場合は、その会員の注文履歴だけを表示するように修正しました。

確認お願いします。