### PR TITLE
add plus-button to admin_items_index

### DIFF
--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -2,7 +2,9 @@
   <div class="row">
     <div class="col">
       <h3 class="my-3">商品一覧</h3>
-
+      <%= link_to  new_admin_item_path, class: 'btn btn-default' do %>
+        <i class="fas fa-plus"></i>
+      <% end %>
       <table class="table">
         <thead>
           <tr>


### PR DESCRIPTION
管理者側の商品一覧ページに商品新規登録ページに遷移するプラスボタンを追加しました。
レイアウトは後回しにしています。