### PR TITLE
会員側の商品詳細ページに売切れの表示追加

### DIFF
--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -10,12 +10,18 @@
       <h2 class="font-weight-bold"><%= @item.name %></h2>
       <p><%= @item.introduction %></p>
       <h4 class="mt-5 mb-4" ><span class="font-weight-bold">¥ <%= @item.add_tax_price.to_s(:delimited) %></span> <span class="small">(税込)</span></h4>
-      <%= form_with model: @cart_items do |f| %>
-      <div class="input-group">
-        <%= f.hidden_field :item_id, value: @item.id %>
-        <%= f.select :amount, options_for_select((1..20).to_a), {include_blank: "個数選択"} ,{class: "form-control rounded"} %>
-        <%= f.submit "カートに入れる",class:"btn btn-success ml-5" %>
-      </div>
+      <% if customer_signed_in? %>
+        <% if @item.is_active? %>
+          <%= form_with model: @cart_items do |f| %>
+          <div class="input-group">
+            <%= f.hidden_field :item_id, value: @item.id %>
+            <%= f.select :amount, options_for_select((1..20).to_a), {include_blank: "個数選択"} ,{class: "form-control rounded"} %>
+            <%= f.submit "カートに入れる",class:"btn btn-success ml-5" %>
+          </div>
+          <% end %>
+        <% else %>
+          <div class="btn btn-danger">売切れ</div>
+        <% end %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
会員側の商品詳細ページにステータスが販売停止中の場合「売切れ」の表示がされるようにしました。
また、会員がログインしている場合にのみカートに追加できるようにしています。