### PR TITLE
管理者側　注文履歴詳細画面修正

### DIFF
--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -3,8 +3,20 @@ class Admin::OrderDetailsController < ApplicationController
 
   def update
     order_detail=OrderDetail.find(params[:id])
+    order=order_detail.order
+    order_details=OrderDetail.where(order_id: order.id)
     order_detail.update(order_detail_params)
-    redirect_to request.referer
+    if params[:order_detail][:making_status] == "in_production"
+      order.update(status: 2)
+      redirect_to request.referer
+    elsif params[:order_detail][:making_status] == "production_complete"
+      if order_details.all?{|order_detail| order_detail.making_status == "production_complete"}
+        order.update(status: 3)
+      end
+      redirect_to request.referer
+    else
+      redirect_to request.referer
+    end
   end
 
   private

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -8,16 +8,24 @@ class Admin::OrdersController < ApplicationController
 
   def update
     order=Order.find(params[:id])
+    order_details=OrderDetail.where(order_id: order.id)
     order.update(order_params)
+    if params[:order][:status] == "payment_confirmation"
+       order_details.each do |order_detail|
+         order_detail.update(making_status: 1)
+       end
+    end
     redirect_to request.referer
-
-
   end
 
   private
 
   def order_params
     params.require(:order).permit(:status)
+  end
+
+  def order_detail_params
+    params.require(:order_detail).permit(:making_status)
   end
 
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -3,7 +3,7 @@ class OrderDetail < ApplicationRecord
      production_not_possible:0,#制作不可
      production_pending:1,#制作待ち
      in_production:2,#製作中
-     production_complete:3,#制作
+     production_complete:3,#制作完了
  }
 
   belongs_to :order


### PR DESCRIPTION
管理者側　注文履歴詳細画面修正しました。
・注文ステータスを"入金確認"に更新すると、製作ステータスが"製作待ち"になるよう修正
・製作ステータスを"製作中"に更新すると、注文ステータスが"製作中"になるよう修正
・製作ステータスを全て"製作完了"に更新すると、注文ステータスが"発送準備中"になるように修正

